### PR TITLE
Update newt/newtmgr to 1.4.1

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,5 @@
 TOOLCHAIN_VERSION:=5
-GO_VERSION:=1.9.2
+GO_VERSION:=1.10.4
 
 all:
 	@echo "make toolchain-image"
@@ -14,8 +14,8 @@ toolchain-image:
 
 newt-binary: clean
 	mkdir -p _scratch
-	docker run --rm -v $(PWD)/_scratch:/go/bin -e "GOPATH=/go" golang:$(GO_VERSION) bash -c "git clone -b mynewt_1_3_0_tag https://github.com/apache/mynewt-newt.git /go/src/mynewt.apache.org/newt && go install mynewt.apache.org/newt/newt && chown $(shell id  -u):$(shell id -g) /go/bin/*"
-	docker run --rm -v $(PWD)/_scratch:/go/bin -e "GOPATH=/go" golang:$(GO_VERSION) bash -c "git clone -b mynewt_1_3_0_tag https://github.com/apache/mynewt-newtmgr.git /go/src/mynewt.apache.org/newtmgr && go install mynewt.apache.org/newtmgr/newtmgr && chown $(shell id  -u):$(shell id -g) /go/bin/*"
+	docker run --rm -v $(PWD)/_scratch:/go/bin -e "GOPATH=/go" golang:$(GO_VERSION) bash -c "git clone -b mynewt_1_4_1_tag https://github.com/apache/mynewt-newt.git /go/src/mynewt.apache.org/newt && go install mynewt.apache.org/newt/newt && chown $(shell id  -u):$(shell id -g) /go/bin/*"
+	docker run --rm -v $(PWD)/_scratch:/go/bin -e "GOPATH=/go" golang:$(GO_VERSION) bash -c "git clone -b mynewt_1_4_1_tag https://github.com/apache/mynewt-newtmgr.git /go/src/mynewt.apache.org/newtmgr && go install mynewt.apache.org/newtmgr/newtmgr && chown $(shell id  -u):$(shell id -g) /go/bin/*"
 
 newt: newt-binary
 	$(eval NEWT_VERSION := $(shell docker run --rm -v $(PWD)/_scratch:/_scratch -w /_scratch golang:$(GO_VERSION) ./newt version | cut -d: -f2))


### PR DESCRIPTION
Updated go image because newt 1.4.x requires go 1.10.x.

Signed-off-by: Fabio Utzig <utzig@apache.org>