### PR TITLE
Added the pyOCD command line tool

### DIFF
--- a/Dockerfile.toolchain
+++ b/Dockerfile.toolchain
@@ -20,6 +20,7 @@ RUN apt-get update && \
                     gcc-arm-embedded \
                     gdb \
                     openocd \
+                    python3-pip \
                     netcat && \
     apt-get autoremove && \
     apt-get clean && \
@@ -30,3 +31,6 @@ COPY JLink_Linux_V${JLINK_RELEASE}_x86_64.deb /tmp/
 RUN dpkg -i /tmp/JLink_Linux_V${JLINK_RELEASE}_x86_64.deb && \
     dpkg-query -l && \
     rm /tmp/JLink_Linux_V${JLINK_RELEASE}_x86_64.deb
+
+RUN pip3 install pyocd
+


### PR DESCRIPTION
pyOCD is an opensource programming and debugging tool for Arm Cortex-M microcontrollers using multiple supported types of USB debug probes. This PR adds the command line tool available as 'pyocd'.

pyOCD license: Apache License 2.0
Further information: https://github.com/pyocd/pyOCD