### PR TITLE
OpenOCD all probes

### DIFF
--- a/Dockerfile.toolchain
+++ b/Dockerfile.toolchain
@@ -52,47 +52,22 @@ RUN cd /usr/src/ \
     && cd openocd \
     && git checkout ${OPENOCD_RELEASE} \
     && ./bootstrap \
-    && ./configure \
-      --enable-aice \
-      --enable-amtjtagaccel \
-      --enable-armjtagew \
-      --enable-at91rm9200 \
-      --enable-bcm2835gpio \
-      --enable-buspirate \
-      --enable-cmsis-dap \
-      --enable-ep93xx \
-      --enable-ft232r \
-      --enable-ftdi \
-      --enable-gw16012 \
-      --enable-imx_gpio \
-      --enable-jlink \
-      --enable-jtag_dpi \
-      --enable-jtag_vpi \
-      --enable-kitprog \
-      --enable-linuxgpiod \
-      --enable-nulink \
-      --enable-opendous \
-      --enable-openjtag \
-      --enable-osbdm \
-      --enable-parport \
-      --enable-parport-giveio \
-      --enable-presto \
-      --enable-remote-bitbang \
-      --enable-rlink \
-      --enable-rshim \
-      --enable-stlink \
-      --enable-sysfsgpio \
-      --enable-ti-icdi \
-      --enable-ulink \
-      --enable-usb-blaster \
-      --enable-usb-blaster-2 \
-      --enable-usbprog \
-      --enable-vsllink \
-      --enable-xlnx-pcie-xvc \
-      --enable-xds110 \
+    && ./configure --enable-cmsis-dap --enable-xlnx-pcie-xvc \
     && make -j"$(nproc)" \
     && make install \
     && cp /usr/local/share/openocd/contrib/60-openocd.rules /etc/udev/rules.d/60-openocd.rules \
-    && rm -rf /usr/src/openocd
+    && rm -rf /usr/src/openocd \
+    && apt -y purge libftdi-dev \
+                    libgpiod-dev \
+                    libhidapi-dev \
+                    libusb-1.0-0-dev \
+                    libusb-dev \
+                    libtool \
+                    make \
+                    automake \
+                    pkg-config \
+                    autoconf \
+                    texinfo
 
+# OpenOCD telnet port
 EXPOSE 4444

--- a/Dockerfile.toolchain
+++ b/Dockerfile.toolchain
@@ -65,14 +65,12 @@ RUN cd /usr/src/ \
       --enable-ftdi \
       --enable-gw16012 \
       --enable-imx_gpio \
-      --enable-ioutil \
       --enable-jlink \
       --enable-jtag_dpi \
       --enable-jtag_vpi \
       --enable-kitprog \
       --enable-linuxgpiod \
       --enable-nulink \
-      --enable-oocd_trace \
       --enable-opendous \
       --enable-openjtag \
       --enable-osbdm \
@@ -92,7 +90,6 @@ RUN cd /usr/src/ \
       --enable-vsllink \
       --enable-xlnx-pcie-xvc \
       --enable-xds110 \
-      --enable-zy1000-master \
     && make -j"$(nproc)" \
     && make install \
     && cp /usr/local/share/openocd/contrib/60-openocd.rules /etc/udev/rules.d/60-openocd.rules \

--- a/Dockerfile.toolchain
+++ b/Dockerfile.toolchain
@@ -4,6 +4,8 @@ MAINTAINER runtime.io <contact@runtime.io>
 ENV DEBIAN_FRONTEND noninteractive
 
 ARG JLINK_RELEASE
+ARG OPENOCD_RELEASE
+
 
 # gcc-arm-embedded is pulled from ppa:team-gcc-arm-embedded/ppa
 RUN apt-get update && \
@@ -19,7 +21,20 @@ RUN apt-get update && \
                     gcc-multilib \
                     gcc-arm-embedded \
                     gdb \
-                    openocd \
+                    libhidapi-hidraw0 \
+                    libftdi-dev \
+                    libgpiod-dev \
+                    libusb-0.1-4 \
+                    libusb-1.0-0 \
+                    libhidapi-dev \
+                    libusb-1.0-0-dev \
+                    libusb-dev \
+                    libtool \
+                    make \
+                    automake \
+                    pkg-config \
+                    autoconf \
+                    texinfo \
                     netcat && \
     apt-get autoremove && \
     apt-get clean && \
@@ -30,3 +45,57 @@ COPY JLink_Linux_V${JLINK_RELEASE}_x86_64.deb /tmp/
 RUN dpkg -i /tmp/JLink_Linux_V${JLINK_RELEASE}_x86_64.deb && \
     dpkg-query -l && \
     rm /tmp/JLink_Linux_V${JLINK_RELEASE}_x86_64.deb
+
+#build and install OPENOCD from repository
+RUN cd /usr/src/ \
+    && git clone --depth 1 https://git.code.sf.net/p/openocd/code openocd \
+    && cd openocd \
+    && git checkout ${OPENOCD_RELEASE} \
+    && ./bootstrap \
+    && ./configure \
+      --enable-aice \
+      --enable-amtjtagaccel \
+      --enable-armjtagew \
+      --enable-at91rm9200 \
+      --enable-bcm2835gpio \
+      --enable-buspirate \
+      --enable-cmsis-dap \
+      --enable-ep93xx \
+      --enable-ft232r \
+      --enable-ftdi \
+      --enable-gw16012 \
+      --enable-imx_gpio \
+      --enable-ioutil \
+      --enable-jlink \
+      --enable-jtag_dpi \
+      --enable-jtag_vpi \
+      --enable-kitprog \
+      --enable-linuxgpiod \
+      --enable-nulink \
+      --enable-oocd_trace \
+      --enable-opendous \
+      --enable-openjtag \
+      --enable-osbdm \
+      --enable-parport \
+      --enable-parport-giveio \
+      --enable-presto \
+      --enable-remote-bitbang \
+      --enable-rlink \
+      --enable-rshim \
+      --enable-stlink \
+      --enable-sysfsgpio \
+      --enable-ti-icdi \
+      --enable-ulink \
+      --enable-usb-blaster \
+      --enable-usb-blaster-2 \
+      --enable-usbprog \
+      --enable-vsllink \
+      --enable-xlnx-pcie-xvc \
+      --enable-xds110 \
+      --enable-zy1000-master \
+    && make -j"$(nproc)" \
+    && make install \
+    && cp /usr/local/share/openocd/contrib/60-openocd.rules /etc/udev/rules.d/60-openocd.rules \
+    && rm -rf /usr/src/openocd
+
+EXPOSE 4444

--- a/Makefile
+++ b/Makefile
@@ -9,6 +9,7 @@ JLINK_RELEASE := 648
 JLINK_BIN := JLink_Linux_V$(JLINK_RELEASE)_x86_64.deb
 JLINK_URL := https://www.segger.com/downloads/jlink
 JLINK_CHKS := $(JLINK_BIN).sha256
+OPENOCD_RELEASE := b3a4f771
 
 all:
 	@echo "make toolchain-image"


### PR DESCRIPTION
Packaged OpenOCD on system lacks some probes like CMSIS-DAP.

This patch download OpenOCD sources and compile it. Version tags are unmantained on original repository, but the commit is referenced as argument to lock the version on docker building (_OPENOCD_RELEASE_).